### PR TITLE
remove restriction of 10 alleles max in multiallelic sites

### DIFF
--- a/benchmarks_test.go
+++ b/benchmarks_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"testing"
+)
+
+// Benchmark for comparing a rune element with a rune variable
+func BenchmarkRuneEquality(b *testing.B) {
+	// Sample rune slice and a rune variable to compare with
+	data := []rune{'a', 'b', 'c'}
+	compareRune := 'a'
+
+	b.ResetTimer() // Reset the timer to exclude setup time
+	for i := 0; i < b.N; i++ {
+		for _, r := range data {
+			if r == compareRune {
+				// Perform some action if equal
+			}
+		}
+	}
+}
+
+// Benchmark for comparing a rune element cast to a string with a string variable
+func BenchmarkStringEquality(b *testing.B) {
+	// Sample rune slice and a string variable to compare with
+	data := []rune{'a', 'b', 'c'}
+	compareString := "a"
+
+	b.ResetTimer() // Reset the timer to exclude setup time
+	for i := 0; i < b.N; i++ {
+		for _, r := range data {
+			if string(r) == compareString {
+				// Perform some action if equal
+			}
+		}
+	}
+}
+
+func BenchmarkStringToRuneEquality(b *testing.B) {
+	// Sample rune slice and a string variable to compare with
+	data := []string{"a", "b", "c"}
+	compareRune := 'a'
+
+	b.ResetTimer() // Reset the timer to exclude setup time
+	for i := 0; i < b.N; i++ {
+		for _, r := range data {
+			if rune(r[0]) == compareRune {
+				// Perform some action if equal
+			}
+		}
+	}
+}
+
+func BenchmarkStringToStringEquality(b *testing.B) {
+	// Sample rune slice and a string variable to compare with
+	data := []string{"a", "b", "c"}
+	compareString := "a"
+
+	b.ResetTimer() // Reset the timer to exclude setup time
+	for i := 0; i < b.N; i++ {
+		for _, r := range data {
+			if string(r[0]) == compareString {
+				// Perform some action if equal
+			}
+		}
+	}
+}
+
+func BenchmarkGenotypeToStringEquality(b *testing.B) {
+	// Sample rune slice and a string variable to compare with
+	data := []string{"0|1", "1|0", "0|1"}
+	compareString := "0"
+
+	b.ResetTimer() // Reset the timer to exclude setup time
+	for i := 0; i < b.N; i++ {
+		for _, r := range data {
+			if string(r[0]) == compareString {
+				// Perform some action if equal
+			}
+		}
+	}
+}
+
+func BenchmarkGenotypeToRuneEquality(b *testing.B) {
+	// Sample rune slice and a string variable to compare with
+	data := []string{"0|1", "1|0", "0|1"}
+	compareString := "0"
+
+	b.ResetTimer() // Reset the timer to exclude setup time
+	for i := 0; i < b.N; i++ {
+		for _, r := range data {
+			if rune(r[0]) == rune(compareString[0]) {
+				// Perform some action if equal
+			}
+		}
+	}
+}
+
+func BenchmarkGenotypeToRuneEqualityWithLengthTest(b *testing.B) {
+	data := []string{"0|1", "1|0", "0|1"}
+	compareString := "0"
+
+	b.ResetTimer() // Reset the timer to exclude setup time
+	for i := 0; i < b.N; i++ {
+		if len(compareString) == 1 {
+			for _, r := range data {
+				if rune(r[0]) == rune(compareString[0]) {
+					// Perform some action if equal
+				}
+			}
+		}
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/bystrogenomics/bystro-vcf
+
+go 1.20
+
+require github.com/akotlar/bystro-utils v0.0.0-20180921004542-b5183a523f20

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/akotlar/bystro-utils v0.0.0-20180921004542-b5183a523f20 h1:DTPJA8O7qs7Dc+YRg9wZusDy/SoVHqn9udRQlr+TSFA=
+github.com/akotlar/bystro-utils v0.0.0-20180921004542-b5183a523f20/go.mod h1:BHUTiQAFM7OSW8+09I/OwWMhgbsonqQ6J8jTlnpOPnk=

--- a/main.go
+++ b/main.go
@@ -957,19 +957,21 @@ SAMPLES:
 			// In this function, we only care about the alleleNum allele
 			// Any diploid genotype with an allele that is longer than 1 number will be longer than 3 characters
 			// E.g., if alleleNum is 10, then 0|10, 10|0, 10|10 will be the shortest possible genotype, 4 characters
-			if (sampleGenotypeField[0] == '0' && string(sampleGenotypeField[2]) == alleleNum) || (string(sampleGenotypeField[0]) == alleleNum && sampleGenotypeField[2] == '0') {
-				totalGtCount += 2
-				totalAltCount += 1
-				hets = append(hets, header[i])
-				continue SAMPLES
-			}
+			if len(alleleNum) == 1 {
+				if (sampleGenotypeField[0] == '0' && sampleGenotypeField[2] == alleleNum[0]) || (sampleGenotypeField[0] == alleleNum[0] && sampleGenotypeField[2] == '0') {
+					totalGtCount += 2
+					totalAltCount += 1
+					hets = append(hets, header[i])
+					continue SAMPLES
+				}
 
-			// Homozygote
-			if string(sampleGenotypeField[0]) == alleleNum && string(sampleGenotypeField[2]) == alleleNum {
-				totalGtCount += 2
-				totalAltCount += 2
-				homs = append(homs, header[i])
-				continue SAMPLES
+				// Homozygote
+				if sampleGenotypeField[0] == alleleNum[0] && sampleGenotypeField[2] == alleleNum[0] {
+					totalGtCount += 2
+					totalAltCount += 2
+					homs = append(homs, header[i])
+					continue SAMPLES
+				}
 			}
 
 			// N|., .|N, .|., N/., ./N, ./. are all considered missing samples, because if one site is missing, the other is likely unreliable

--- a/main.go
+++ b/main.go
@@ -430,8 +430,6 @@ func processLines(header []string, numChars int, config *Config, queue chan [][]
 		log.Printf("Found 9 header fields. When genotypes present, we expect 1+ samples after FORMAT (10 fields minimum)")
 	}
 
-	iLookup := []rune{'1', '2', '3', '4', '5', '6', '7', '8', '9'}
-
 	var output bytes.Buffer
 	var record []string
 
@@ -454,24 +452,19 @@ func processLines(header []string, numChars int, config *Config, queue chan [][]
 			}
 
 			siteType, positions, refs, alts, altIndices := getAlleles(record[chromIdx], record[posIdx], record[refIdx], record[altIdx])
+
 			if len(altIndices) == 0 {
 				continue
 			}
 
 			multiallelic = siteType == parse.Multi
 
-			// if last index > 9 then we can't accept the site, since won't be able
-			// to identify het/hom status
-			if altIndices[len(altIndices)-1] >= len(iLookup) {
-				log.Printf("%s %s:%s: We currently don't support sites with > %d minor alleles, found %d", record[chromIdx], record[posIdx], errorLvl, len(iLookup), len(altIndices))
-				continue
-			}
-
 			for i := range alts {
+				strAlt := strconv.Itoa(altIndices[i] + 1)
 				// If no samples are provided, annotate what we can, skipping hets and homs
 				// If samples are provided, but only missing genotypes, skip the site altogether
 				if numSamples > 0 {
-					homs, hets, missing, ac, an = makeHetHomozygotes(record, header, iLookup[altIndices[i]])
+					homs, hets, missing, ac, an = makeHetHomozygotes(record, header, strAlt)
 
 					if len(homs) == 0 && len(hets) == 0 {
 						continue
@@ -567,7 +560,7 @@ func processLines(header []string, numChars int, config *Config, queue chan [][]
 				output.WriteByte(tabByte)
 				output.WriteString(strconv.Itoa(an))
 				output.WriteByte(tabByte)
-				
+
 				// TODO: can ac == 0 && (len(het) > 0 || len(hom) > 0) occur?
 				if ac == 0 {
 					output.WriteByte(zeroByte)
@@ -609,7 +602,6 @@ func processLines(header []string, numChars int, config *Config, queue chan [][]
 
 		fileMutex.Unlock()
 	}
-
 
 	complete <- true
 }
@@ -931,22 +923,12 @@ func getAlleles(chrom string, pos string, ref string, alt string) (string, []str
 	return parse.Snp, positions, references, alleles, indexes
 }
 
-// Current limitations: Does not support alleleIdx > 9, or sites which have 2 digits allele numbers
-// This allows us to improve performance, decrease code verbosity
-// Most multialellics with > 10 alleles will be false positives
-// because a true site would require a mutation rate of >> 1e-8 (say in chromosomal instability) and 10k samples
-// or an effective population size of billions (vs 10k expected) ; else .001^10 == 10^-30 == never happens
-
 // TODO: decide whether to be more strict about missing genotypes
 // Currently some garbage like .... would be considered "missing"
-func makeHetHomozygotes(fields []string, header []string, alleleNum rune) ([]string, []string, []string, int, int) {
-	simpleGt := !strings.Contains(fields[formatIdx], ":")
-
+func makeHetHomozygotes(fields []string, header []string, alleleNum string) ([]string, []string, []string, int, int) {
 	var homs []string
 	var hets []string
 	var missing []string
-
-	var gt []string
 
 	var gtCount int
 	var altCount int
@@ -967,175 +949,70 @@ SAMPLES:
 	// NOTE: If any errors encountered, all genotypes in row will be skipped and logged, since
 	// this represents a likely corruption of data
 	for i := 9; i < len(header); i++ {
-		// If any 1 allele missing the genotype is, by definition missing
-		// Applies to haploid as well as diploid+ sites
-		if fields[i][0] == '.' {
+		field := fields[i]
+
+		if field[0] == '.' {
 			missing = append(missing, header[i])
 			continue
 		}
 
-		// haploid
-		if len(fields[i]) == 1 || fields[i][1] == ':' {
-			if fields[i][0] == '0' {
-				totalGtCount++
+		// Speed up the common case, bi-allelic sites
+		if len(fields[i]) >= 3 {
+			if fields[i][0:3] == "0|0" || fields[i][0:3] == "0/0" {
+				totalGtCount += 2
 				continue
 			}
 
-			// We don't support haploid genotypes very well; I will count such sites
-			// homozygous, because Dave Cutler says that is what people would mostly expect
-			// Note: downstream tools will typicaly consider homozygotes to have 2 copies of the alt
-			// and hets to have 1 copy of the alt, so special consideration must be made for haploids
-			// in such tools
-			if rune(fields[i][0]) == alleleNum {
-				totalAltCount++
-				totalGtCount++
-				homs = append(homs, header[i])
-				continue
-			}
-
-			continue
-		}
-
-		if len(fields[i]) < 3 {
-			log.Printf("%s:%s : Skipping. Couldn't decode genotype %s (expected at least 3 characters)", fields[chromIdx], fields[posIdx], fields[i])
-			return nil, nil, nil, 0, 0
-		}
-
-		// If for some reason the first allele call isn't . but 2nd is,
-		// send that to missing too
-		// Important to check here, because even if !simpleGt, GATK
-		// will not output genotype QC data for missing genotypes
-		// i.e, even with a format string (0/0:1,2:3:4:etc), we will see './.'
-		if fields[i][2] == '.' {
-			missing = append(missing, header[i])
-			continue
-		}
-
-		// Allow for some rare cases where > 10 alleles (including reference)
-		if fields[i][1] == '|' || fields[i][2] == '|' {
-			// Speed up the most common cases
-			if simpleGt {
-				if fields[i] == "0|0" {
+			if alleleNum == "1" {
+				if fields[i][0:3] == "0|1" || fields[i][0:3] == "1|0" || fields[i][0:3] == "1/0" || fields[i][0:3] == "0/1" {
 					totalGtCount += 2
+					totalAltCount += 1
+					hets = append(hets, header[i])
 					continue
 				}
 
-				// No longer strictly needed because of line 863
-				// if fields[i] == ".|." {
-				//   missing = append(missing, header[i])
-				//   continue
-				// }
-
-				if alleleNum == '1' {
-					if fields[i] == "0|1" || fields[i] == "1|0" {
-						totalGtCount += 2
-						totalAltCount++
-						hets = append(hets, header[i])
-						continue
-					}
-
-					if fields[i] == "1|1" {
-						totalGtCount += 2
-						totalAltCount += 2
-						homs = append(homs, header[i])
-						continue
-					}
-				}
-			} else {
-				if fields[i][0:4] == "0|0:" {
+				if fields[i][0:3] == "1|1" || fields[i][0:3] == "1/1" {
 					totalGtCount += 2
+					totalAltCount += 2
+					homs = append(homs, header[i])
 					continue
 				}
-
-				if alleleNum == '1' {
-					if fields[i][0:4] == "0|1:" || fields[i][0:4] == "1|0:" {
-						totalGtCount += 2
-						totalAltCount++
-						hets = append(hets, header[i])
-						continue
-					}
-
-					if fields[i][0:4] == "1|1:" {
-						totalGtCount += 2
-						totalAltCount += 2
-						homs = append(homs, header[i])
-						continue
-					}
-				}
 			}
+		}
 
-			gt = strings.Split(fields[i], "|")
+		// Split the field on the colon to separate alleles from additional information
+		parts := strings.SplitN(field, ":", 2)
+		alleleField := parts[0]
+
+		var sep string
+		if strings.Contains(alleleField, "|") {
+			sep = "|"
+		} else if strings.Contains(alleleField, "/") {
+			sep = "/"
+		} else if len(alleleField) == 1 {
+			sep = ""
 		} else {
-			// alleles separated by /, or some very malformed file
-			if simpleGt {
-				if fields[i] == "0/0" {
-					totalGtCount += 2
-					continue
-				}
-
-				if alleleNum == '1' {
-					if fields[i] == "0/1" || fields[i] == "1/0" {
-						totalGtCount += 2
-						totalAltCount++
-						hets = append(hets, header[i])
-						continue
-					}
-
-					if fields[i] == "1/1" {
-						totalGtCount += 2
-						totalAltCount += 2
-						homs = append(homs, header[i])
-						continue
-					}
-				}
-			} else {
-				if len(fields[i]) < 4 {
-					log.Printf("%s:%s : Skipping. Couldn't decode genotype %s (expected FORMAT data)", fields[chromIdx], fields[posIdx], fields[i])
-					return nil, nil, nil, 0, 0
-				}
-
-				if fields[i][0:4] == "0/0:" {
-					totalGtCount += 2
-					continue
-				}
-
-				if alleleNum == '1' {
-					if fields[i][0:4] == "0/1:" || fields[i][0:4] == "1/0:" {
-						totalGtCount += 2
-						totalAltCount++
-						hets = append(hets, header[i])
-						continue
-					}
-
-					if fields[i] == "1/1:" {
-						totalGtCount += 2
-						totalAltCount += 2
-						homs = append(homs, header[i])
-						continue
-					}
-				}
-			}
-
-			gt = strings.Split(fields[i], "/")
-		}
-
-		//https://play.golang.org/p/zjUf2rhBHn
-		if len(gt) == 1 {
-			log.Printf("%s:%s : Skipping. Couldn't decode genotype %s", fields[chromIdx], fields[posIdx], fields[i])
+			log.Printf("%s:%s : Skipping. Couldn't decode genotype %s", fields[chromIdx], fields[posIdx], field)
 			return nil, nil, nil, 0, 0
 		}
 
-		// We should only get here for triploid+ and multiallelics
+		var alleles []string
+		if sep != "" {
+			alleles = strings.Split(alleleField, sep)
+		} else {
+			alleles = []string{alleleField}
+		}
+
 		altCount = 0
 		gtCount = 0
-		// log.Print(gt)
-		for _, val := range gt {
-			if val[0] == '.' {
+
+		for _, allele := range alleles {
+			if allele == "." {
 				missing = append(missing, header[i])
 				continue SAMPLES
 			}
 
-			if rune(val[0]) == alleleNum {
+			if allele == alleleNum {
 				altCount++
 			}
 

--- a/main_test.go
+++ b/main_test.go
@@ -652,7 +652,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields := append(sharedFieldsGT, "0|0", "0|0", "0|0", "0|0")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an := makeHetHomozygotes(fields, header, '1')
+	actualHoms, actualHets, missing, ac, an := makeHetHomozygotes(fields, header, "1")
 
 	sampleMaf := float64(ac) / float64(an)
 
@@ -671,7 +671,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "0|1", "0|1", "0|1", "0|1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '1')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "1")
 
 	sampleMaf = float64(ac) / float64(an)
 
@@ -691,7 +691,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, ".|.", ".|.", ".|1", "1|.")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '1')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "1")
 
 	sampleMaf = 0
 
@@ -710,7 +710,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, ".|1", "0|1", "0|1", "0|1", strconv.FormatFloat(sampleMaf, 'G', 3, 64))
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '1')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "1")
 
 	sampleMaf = float64(ac) / float64(an)
 
@@ -731,7 +731,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "1|.", "0|1", "0|1", "0|1", strconv.FormatFloat(sampleMaf, 'G', 3, 64))
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '1')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "1")
 
 	sampleMaf = float64(ac) / float64(an)
 
@@ -750,7 +750,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "1|1", "1|1", "0|1", "0|1", strconv.FormatFloat(sampleMaf, 'G', 3, 64))
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '1')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "1")
 
 	sampleMaf = float64(ac) / float64(an)
 
@@ -769,7 +769,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "1|2", "1|1", "0|1", "0|1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '1')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "1")
 
 	sampleMaf = float64(ac) / float64(an)
 
@@ -791,7 +791,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "1|2", "1|1", "0|1", "0|1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '2')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "2")
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 0 && len(actualHets) == 1 {
@@ -809,7 +809,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGTcomplex, "1|2:-0.03,-1.12,-5.00", "1|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '2')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "2")
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 0 && len(actualHets) == 1 {
@@ -827,7 +827,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGTcomplex, "1|2|1:-0.03,-1.12,-5.00", "1|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '2')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "2")
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 0 && len(actualHets) == 1 {
@@ -845,7 +845,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "1|2|1", "1|1", "0|1", "0|1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '2')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "2")
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 0 && len(actualHets) == 1 {
@@ -863,7 +863,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGTcomplex, "2|2|2:-0.03,-1.12,-5.00", "1|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '2')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "2")
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 1 && len(actualHets) == 0 {
@@ -881,7 +881,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "2|2|2", "1|1", "0|1", "0|1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '2')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "2")
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 1 && len(actualHets) == 0 {
@@ -908,7 +908,7 @@ func TestMakeHetHomozygotesHaploid(t *testing.T) {
 	fields := append(sharedFieldsGT, "0", ".", "1", "0")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an := makeHetHomozygotes(fields, header, '1')
+	actualHoms, actualHets, missing, ac, an := makeHetHomozygotes(fields, header, "1")
 	sampleMaf := float64(ac) / float64(an)
 
 	if len(actualHoms) == 1 && len(actualHets) == 0 && len(missing) == 1 {
@@ -926,7 +926,7 @@ func TestMakeHetHomozygotesHaploid(t *testing.T) {
 	fields = append(sharedFieldsGTcomplex, "0:1", ".:1", "1:1", "0:1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, '1')
+	actualHoms, actualHets, missing, ac, an = makeHetHomozygotes(fields, header, "1")
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 1 && len(actualHets) == 0 && len(missing) == 1 {
@@ -2845,16 +2845,19 @@ func TestMNP(t *testing.T) {
 
 func TestManyAlleles(t *testing.T) {
 	versionLine := "##fileformat=VCFv4.x"
-	header := strings.Join([]string{"#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO"}, "\t")
+	header := strings.Join([]string{"#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "S1", "S2", "S3", "S4", "S5", "S6", "S7", "S8", "S9", "S10", "S11"}, "\t")
+	record := strings.Join([]string{"1", "1000", "rs1", "A", "AA,AC,AG,AT,C,G,T,ATA,ATC,ATG,ATT", ".", "PASS", "DP=100", "GT", "1|1", "2|2", "3|3", "4|4", "5|5", "6|6", "7|7", "8|8", "9|9", "10|10", "11|11"}, "\t")
 
-	// Define a interstital insertion, between C & T
-	record := strings.Join([]string{"10", "1", "rs1", "CTTTTT", "CTTTTTTTT,CTTTTA,CTTTTTTT,CTT,CTTTTTT,C,CTTTT,CT,CTTTTTTTTTTTTTG,CTTTTTTTTTA", "100", "PASS", "AC=1"}, "\t")
+	expectedAlleles := []string{"+A", "+C", "+G", "+T", "C", "G", "T", "+TA", "+TC", "+TG", "+TT"}
+
+	allowedFilters := map[string]bool{"PASS": true, ".": true}
 
 	lines := versionLine + "\n" + header + "\n" + record + "\n"
 	reader := bufio.NewReader(strings.NewReader(lines))
 
-	config := Config{emptyField: "!", fieldDelimiter: ";"}
+	config := Config{emptyField: "!", fieldDelimiter: ";", allowedFilters: allowedFilters}
 
+	index := -1
 	byteBuf := new(bytes.Buffer)
 	w := bufio.NewWriter(byteBuf)
 
@@ -2863,7 +2866,17 @@ func TestManyAlleles(t *testing.T) {
 	readVcf(&config, reader, w)
 	w.Flush()
 
-	if len(results.Text()) > 0 {
-		t.Error("Expect 0 results when > 9 alleles")
+	for results.Scan() {
+		index++
+
+		resultRow := strings.Split(results.Text(), "\t")
+
+		if resultRow[altIdx] != expectedAlleles[index] {
+			t.Errorf("alt should be %s, but is %s", expectedAlleles[index], resultRow[altIdx])
+		}
+	}
+
+	if index+1 != 11 {
+		t.Errorf("NOT OK: 11 results not found. Found %d", index+1)
 	}
 }


### PR DESCRIPTION
* Simplifies makeHetHomozygotes and removes the rune-by-rune reading in favor of string by string, which enables us to have unlimited numbers of alleles. This is useful because dbSNP VCF format has many submissions with > 9 alleles

Previously we used a fast parsing strategy, which took a string like "0|1" and read it as runes (ascii code points) '0', '|', and '1'. This allowed us to avoid splitting on "|" and to also allow us to not split on ":" should there be metadata about the genotypes (e.g. GT:AD). 

Now, we do the necessary splitting, and evaluate each allele as a string, which may be composed of multiple runes, allowing genotypes like "100|0" to be evaluated (for a hypothetical site with >= 100 alternate alleles).

We still keep a fast path for biallelic sites, entirely avoiding the need to do any processing besides exact match on the most common genotypes (0|0, 0/0, 1|0, 1/0, 0/1, 0|1).

Addresses #7 