### PR TITLE
Make it possible to not write standard annotation output

### DIFF
--- a/arrow/arrow.go
+++ b/arrow/arrow.go
@@ -12,33 +12,27 @@ import (
 )
 
 type ArrowWriter struct {
-	filePath string
-	schema   *arrow.Schema
-	writer   *ipc.FileWriter
-	mu       sync.Mutex
+	schema *arrow.Schema
+	writer *ipc.FileWriter
+	mu     sync.Mutex
 }
 
 // Create a new ArrowWriter. The number of fields in fieldNames and fieldTypes
 // must match. The number of rows in each chunk is determined by chunkSize.
 // The ArrowWriter will write to filePath.
 // This writing operation is threadsafe.
-func NewArrowIPCFileWriter(filePath string, fieldNames []string, fieldTypes []arrow.DataType, options ...ipc.Option) (*ArrowWriter, error) {
+func NewArrowIPCFileWriter(f *os.File, fieldNames []string, fieldTypes []arrow.DataType, options ...ipc.Option) (*ArrowWriter, error) {
 	schema := makeSchema(fieldNames, fieldTypes)
-	file, err := os.Create(filePath)
-	if err != nil {
-		return nil, err
-	}
 
 	schemaOption := ipc.WithSchema(schema)
-	writer, err := ipc.NewFileWriter(file, append([]ipc.Option{schemaOption}, options...)...)
+	writer, err := ipc.NewFileWriter(f, append([]ipc.Option{schemaOption}, options...)...)
 	if err != nil {
 		return nil, err
 	}
 
 	return &ArrowWriter{
-		filePath: filePath,
-		schema:   schema,
-		writer:   writer,
+		schema: schema,
+		writer: writer,
 	}, nil
 }
 

--- a/arrow/arrow.go
+++ b/arrow/arrow.go
@@ -22,14 +22,15 @@ type ArrowWriter struct {
 // must match. The number of rows in each chunk is determined by chunkSize.
 // The ArrowWriter will write to filePath.
 // This writing operation is threadsafe.
-func NewArrowWriter(filePath string, fieldNames []string, fieldTypes []arrow.DataType, options []ipc.Option) (*ArrowWriter, error) {
+func NewArrowIPCFileWriter(filePath string, fieldNames []string, fieldTypes []arrow.DataType, options ...ipc.Option) (*ArrowWriter, error) {
 	schema := makeSchema(fieldNames, fieldTypes)
 	file, err := os.Create(filePath)
 	if err != nil {
 		return nil, err
 	}
 
-	writer, err := ipc.NewFileWriter(file, append([]ipc.Option{ipc.WithSchema(schema)}, options...)...)
+	schemaOption := ipc.WithSchema(schema)
+	writer, err := ipc.NewFileWriter(file, append([]ipc.Option{schemaOption}, options...)...)
 	if err != nil {
 		return nil, err
 	}

--- a/arrow/arrow_test.go
+++ b/arrow/arrow_test.go
@@ -287,7 +287,13 @@ func runConcurrentTest(compress bool) {
 	fieldNames := []string{"Field1", "Field2"}
 	fieldTypes := []arrow.DataType{arrow.PrimitiveTypes.Uint16, arrow.PrimitiveTypes.Uint16}
 
-	writer, err := NewArrowIPCFileWriter(file, fieldNames, fieldTypes)
+	var writer *ArrowWriter
+	if compress {
+		writer, err = NewArrowIPCFileWriter(file, fieldNames, fieldTypes, ipc.WithZstd())
+	} else {
+		writer, err = NewArrowIPCFileWriter(file, fieldNames, fieldTypes)
+	}
+
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/arrow/arrow_test.go
+++ b/arrow/arrow_test.go
@@ -356,7 +356,6 @@ func TestNewArrowIPCFileWriterWithZstdOption(t *testing.T) {
 	fieldNames := []string{"field1", "field2"}
 	fieldTypes := []arrow.DataType{arrow.PrimitiveTypes.Int32, arrow.PrimitiveTypes.Float64}
 
-	// Call the constructor
 	_, err = NewArrowIPCFileWriter(file, fieldNames, fieldTypes, ipc.WithZstd())
 	if err != nil {
 		t.Errorf("Unexpected error when passing WithZstd as an option: %v", err)

--- a/arrow/arrow_test.go
+++ b/arrow/arrow_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"sync"
@@ -168,7 +169,7 @@ func TestArrowWriteRead(t *testing.T) {
 		rows[i] = []any{uint16(i), uint16(i + 1), uint16(i + 2)}
 	}
 
-	writer, err := NewArrowWriter(filePath, fieldNames, fieldTypes, nil)
+	writer, err := NewArrowIPCFileWriter(filePath, fieldNames, fieldTypes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -235,7 +236,7 @@ func TestArrowWriterHandlesNullValues(t *testing.T) {
 		fieldNames[i] = fmt.Sprintf("Field %d", i)
 	}
 
-	writer, err := NewArrowWriter(filePath, fieldNames, fieldTypes, nil)
+	writer, err := NewArrowIPCFileWriter(filePath, fieldNames, fieldTypes)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -267,7 +268,7 @@ func runConcurrentTest(compress bool) {
 	fieldNames := []string{"Field1", "Field2"}
 	fieldTypes := []arrow.DataType{arrow.PrimitiveTypes.Uint16, arrow.PrimitiveTypes.Uint16}
 
-	writer, err := NewArrowWriter(filePath, fieldNames, fieldTypes, nil)
+	writer, err := NewArrowIPCFileWriter(filePath, fieldNames, fieldTypes)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -323,4 +324,19 @@ func TestArrowWriterConcurrency(t *testing.T) {
 
 func TestArrowWriterConcurrencyWithCompression(t *testing.T) {
 	runConcurrentTest(true)
+}
+
+func TestNewArrowIPCFileWriterWithZstdOption(t *testing.T) {
+	filePath := filepath.Join(os.TempDir(), "test.arrow")
+	fieldNames := []string{"field1", "field2"}
+	fieldTypes := []arrow.DataType{arrow.PrimitiveTypes.Int32, arrow.PrimitiveTypes.Float64}
+
+	// Call the constructor
+	_, err := NewArrowIPCFileWriter(filePath, fieldNames, fieldTypes, ipc.WithZstd())
+	if err != nil {
+		t.Errorf("Unexpected error when passing WithZstd as an option: %v", err)
+	}
+
+	// Cleanup
+	os.Remove(filePath)
 }

--- a/main.go
+++ b/main.go
@@ -314,8 +314,13 @@ func readVcf(config *Config, reader *bufio.Reader, writer *bufio.Writer) {
 			fieldTypes[i] = arrow.PrimitiveTypes.Int16
 		}
 
-		var err error
-		arrowWriter, err = bystroArrow.NewArrowIPCFileWriter(config.dosageMatrixOutPath, fieldNames, fieldTypes, ipc.WithZstd())
+		file, err := os.Create(config.dosageMatrixOutPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer file.Close()
+
+		arrowWriter, err = bystroArrow.NewArrowIPCFileWriter(file, fieldNames, fieldTypes, ipc.WithZstd())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -564,7 +564,7 @@ func processLines(header []string, numChars int, config *Config, queue chan [][]
 					arrowBuilder.WriteRow(arrowRow)
 				}
 
-				if !config.noOut {
+				if needsLabels {
 					output.WriteString(chrom)
 					output.WriteByte(tabByte)
 

--- a/main.go
+++ b/main.go
@@ -161,8 +161,8 @@ func main() {
 		log.Fatal("Cannot specify --noOut and --out")
 	}
 
-	if config.noOut && config.outPath == "" && config.dosageMatrixOutPath == "" {
-		log.Fatal("When specifying --noOut, must specify either --out or --dosageOutput")
+	if config.noOut && config.dosageMatrixOutPath == "" {
+		log.Fatal("When specifying --noOut, must specify --dosageOutput")
 	}
 
 	if !config.noOut {

--- a/main.go
+++ b/main.go
@@ -311,7 +311,7 @@ func readVcf(config *Config, reader *bufio.Reader, writer *bufio.Writer) {
 		fieldTypes := make([]arrow.DataType, len(fieldNames))
 		fieldTypes[0] = arrow.BinaryTypes.String
 		for i := 1; i < len(fieldNames); i++ {
-			fieldTypes[i] = arrow.PrimitiveTypes.Int16
+			fieldTypes[i] = arrow.PrimitiveTypes.Uint16
 		}
 
 		file, err := os.Create(config.dosageMatrixOutPath)
@@ -1053,7 +1053,7 @@ SAMPLES:
 				totalGtCount += 2
 
 				if needsDosages {
-					dosages = append(dosages, int16(0))
+					dosages = append(dosages, uint16(0))
 				}
 
 				continue SAMPLES
@@ -1072,7 +1072,7 @@ SAMPLES:
 					}
 
 					if needsDosages {
-						dosages = append(dosages, int16(1))
+						dosages = append(dosages, uint16(1))
 					}
 
 					continue SAMPLES
@@ -1088,7 +1088,7 @@ SAMPLES:
 					}
 
 					if needsDosages {
-						dosages = append(dosages, int16(2))
+						dosages = append(dosages, uint16(2))
 					}
 
 					continue SAMPLES
@@ -1156,7 +1156,7 @@ SAMPLES:
 		totalAltCount += altCount
 
 		if needsDosages {
-			dosages = append(dosages, int16(altCount))
+			dosages = append(dosages, uint16(altCount))
 		}
 
 		if altCount == 0 {

--- a/main.go
+++ b/main.go
@@ -314,10 +314,8 @@ func readVcf(config *Config, reader *bufio.Reader, writer *bufio.Writer) {
 			fieldTypes[i] = arrow.PrimitiveTypes.Int16
 		}
 
-		options := []ipc.Option{ipc.WithZstd()}
-
 		var err error
-		arrowWriter, err = bystroArrow.NewArrowWriter(config.dosageMatrixOutPath, fieldNames, fieldTypes, options)
+		arrowWriter, err = bystroArrow.NewArrowIPCFileWriter(config.dosageMatrixOutPath, fieldNames, fieldTypes, ipc.WithZstd())
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -63,6 +63,7 @@ const precision = 3
 type Config struct {
 	inPath              string
 	outPath             string
+	noOut               bool
 	dosageMatrixOutPath string
 	sampleListPath      string
 	famPath             string
@@ -83,9 +84,10 @@ func setup(args []string) *Config {
 	flag.StringVar(&config.inPath, "in", "", "The input file path (optional: default stdin)")
 	flag.StringVar(&config.famPath, "fam", "", "The fam file path (optional)")
 	flag.StringVar(&config.errPath, "err", "", "The log path (optional: default stderr)")
-	flag.StringVar(&config.outPath, "out", "", "The output path (optional: default stdout")
+	flag.StringVar(&config.outPath, "out", "", "The output path (optional: default stdout)")
+	flag.BoolVar(&config.noOut, "noOut", false, "Skip writing output (useful in conjunction with dosageOutput)")
 	flag.StringVar(&config.dosageMatrixOutPath, "dosageOutput", "", "The output path for the dosage matrix (optional). If not provided, dosage matrix will not be output.")
-	flag.StringVar(&config.sampleListPath, "sample", "", "The output path of the sample list (optional: default stdout")
+	flag.StringVar(&config.sampleListPath, "sample", "", "The output path of the sample list (optional: default stdout)")
 	flag.StringVar(&config.emptyField, "emptyField", "!", "The output path for the JSON output (optional)")
 	flag.StringVar(&config.fieldDelimiter, "fieldDelimiter", ";", "The output path for the JSON output (optional)")
 	flag.BoolVar(&config.keepID, "keepId", false, "Retain the ID field in output")
@@ -154,18 +156,29 @@ func main() {
 	}
 
 	outFh := (*os.File)(nil)
-	if config.outPath != "" {
-		var err error
 
-		outFh, err = os.OpenFile(config.outPath, os.O_WRONLY|os.O_CREATE, 0644)
-		if err != nil {
-			log.Fatal(err)
-		}
-	} else {
-		outFh = os.Stdout
+	if config.noOut && config.outPath != "" {
+		log.Fatal("Cannot specify --noOut and --out")
 	}
 
-	defer outFh.Close()
+	if config.noOut && config.outPath == "" && config.dosageMatrixOutPath == "" {
+		log.Fatal("When specifying --noOut, must specify either --out or --dosageOutput")
+	}
+
+	if !config.noOut {
+		if config.outPath != "" {
+			var err error
+
+			outFh, err = os.OpenFile(config.outPath, os.O_WRONLY|os.O_CREATE, 0644)
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			outFh = os.Stdout
+		}
+
+		defer outFh.Close()
+	}
 
 	if config.cpuProfile != "" {
 		f, err := os.Create(config.cpuProfile)
@@ -178,22 +191,28 @@ func main() {
 
 	reader := bufio.NewReaderSize(inFh, 48*1024*1024)
 
-	writer := bufio.NewWriterSize(outFh, 48*1024*1024)
+	var writer *bufio.Writer
 
-	fmt.Fprintln(writer, stringHeader(config))
+	if !config.noOut {
+		writer = bufio.NewWriterSize(outFh, 48*1024*1024)
+
+		fmt.Fprintln(writer, stringHeader(config))
+	}
 
 	readVcf(config, reader, writer)
 
-	err := writer.Flush()
+	if !config.noOut {
+		err := writer.Flush()
 
-	if err != nil {
-		log.Fatal(err)
-	}
+		if err != nil {
+			log.Fatal(err)
+		}
 
-	err = outFh.Close()
+		err = outFh.Close()
 
-	if err != nil {
-		log.Print(err)
+		if err != nil {
+			log.Print(err)
+		}
 	}
 }
 
@@ -276,10 +295,12 @@ func readVcf(config *Config, reader *bufio.Reader, writer *bufio.Writer) {
 
 	parse.NormalizeHeader(header)
 
-	err = writeSampleListIfWanted(config, header)
+	if !config.noOut {
+		err = writeSampleListIfWanted(config, header)
 
-	if err != nil {
-		log.Fatal("Couldn't write sample list file")
+		if err != nil {
+			log.Fatal("Couldn't write sample list file")
+		}
 	}
 
 	var arrowWriter *bystroArrow.ArrowWriter
@@ -478,7 +499,7 @@ func processLines(header []string, numChars int, config *Config, queue chan [][]
 	}
 
 	for lines := range queue {
-		if output.Len() >= 2e6 {
+		if !config.noOut && output.Len() >= 2e6 {
 			fileMutex.Lock()
 
 			writer.Write(output.Bytes())
@@ -530,21 +551,6 @@ func processLines(header []string, numChars int, config *Config, queue chan [][]
 					chrom = record[chromIdx]
 				}
 
-				output.WriteString(chrom)
-				output.WriteByte(tabByte)
-
-				output.WriteString(positions[i])
-				output.WriteByte(tabByte)
-
-				output.WriteString(siteType)
-				output.WriteByte(tabByte)
-
-				output.WriteByte(refs[i])
-				output.WriteByte(tabByte)
-
-				output.WriteString(alts[i])
-				output.WriteByte(tabByte)
-
 				if arrowBuilder != nil {
 					arrowRow = append(arrowRow, fmt.Sprintf("%s:%s:%s:%s", chrom, positions[i], string(refs[i]), alts[i]))
 
@@ -555,99 +561,116 @@ func processLines(header []string, numChars int, config *Config, queue chan [][]
 					arrowBuilder.WriteRow(arrowRow)
 				}
 
-				if multiallelic {
-					output.WriteString(parse.NotTrTv)
-				} else {
-					output.WriteString(parse.GetTrTv(string(refs[i]), alts[i]))
+				if !config.noOut {
+					output.WriteString(chrom)
+					output.WriteByte(tabByte)
+
+					output.WriteString(positions[i])
+					output.WriteByte(tabByte)
+
+					output.WriteString(siteType)
+					output.WriteByte(tabByte)
+
+					output.WriteByte(refs[i])
+					output.WriteByte(tabByte)
+
+					output.WriteString(alts[i])
+					output.WriteByte(tabByte)
+
+					if multiallelic {
+						output.WriteString(parse.NotTrTv)
+					} else {
+						output.WriteString(parse.GetTrTv(string(refs[i]), alts[i]))
+					}
+
+					output.WriteByte(tabByte)
+
+					// Write missing samples
+					// heterozygotes \t heterozygosity
+					if len(hets) == 0 {
+						output.WriteString(emptyField)
+						output.WriteByte(tabByte)
+						output.WriteByte(zeroByte)
+					} else {
+						output.WriteString(strings.Join(hets, fieldDelim))
+						output.WriteByte(tabByte)
+
+						// This gives plenty precision; we are mostly interested in
+						// the first or maybe 2-3 significant digits
+						// https://play.golang.org/p/Ux-QmClaJG
+						// Also, gnomAD seems to use 6 bits of precision
+						// the bitSize == 64 allows us to round properly past 6 s.f
+						// Note: 'G' requires these numbers to be < 0 for proper precision
+						// (elase only 6 s.f total, rather than after decimal)
+						output.WriteString(strconv.FormatFloat(float64(len(hets))/effectiveSamples, 'G', precision, 64))
+					}
+
+					output.WriteByte(tabByte)
+
+					// Write missing samples
+					// homozygotes \t homozygosity
+					if len(homs) == 0 {
+						output.WriteString(emptyField)
+						output.WriteByte(tabByte)
+						output.WriteByte(zeroByte)
+					} else {
+						output.WriteString(strings.Join(homs, fieldDelim))
+						output.WriteByte(tabByte)
+						output.WriteString(strconv.FormatFloat(float64(len(homs))/effectiveSamples, 'G', precision, 64))
+					}
+
+					output.WriteByte(tabByte)
+
+					// Write missing samples
+					// missingGenos \t missingness
+					if len(missing) == 0 {
+						output.WriteString(emptyField)
+						output.WriteByte(tabByte)
+						output.WriteByte(zeroByte)
+					} else {
+						output.WriteString(strings.Join(missing, fieldDelim))
+						output.WriteByte(tabByte)
+						output.WriteString(strconv.FormatFloat(float64(len(missing))/numSamples, 'G', precision, 64))
+					}
+
+					// Write the sample minor allele frequency
+					output.WriteByte(tabByte)
+
+					output.WriteString(strconv.Itoa(ac))
+					output.WriteByte(tabByte)
+					output.WriteString(strconv.Itoa(an))
+					output.WriteByte(tabByte)
+
+					// TODO: can ac == 0 && (len(het) > 0 || len(hom) > 0) occur?
+					if ac == 0 {
+						output.WriteByte(zeroByte)
+					} else {
+						output.WriteString(strconv.FormatFloat(float64(ac)/float64(an), 'G', precision, 64))
+					}
+
+					/******************* Optional Fields ***********************/
+					if keepPos == true {
+						output.WriteByte(tabByte)
+						output.WriteString(record[posIdx])
+					}
+
+					if keepID == true {
+						output.WriteByte(tabByte)
+						output.WriteString(record[idIdx])
+					}
+
+					if keepInfo == true {
+						// Write the index of the allele, to allow users to segregate data in the INFO field
+						output.WriteByte(tabByte)
+						output.WriteString(strconv.Itoa(altIndices[i]))
+
+						// Write info for all indices
+						output.WriteByte(tabByte)
+						output.WriteString(record[infoIdx])
+					}
+
+					output.WriteByte(clByte)
 				}
-
-				output.WriteByte(tabByte)
-
-				// Write missing samples
-				// heterozygotes \t heterozygosity
-				if len(hets) == 0 {
-					output.WriteString(emptyField)
-					output.WriteByte(tabByte)
-					output.WriteByte(zeroByte)
-				} else {
-					output.WriteString(strings.Join(hets, fieldDelim))
-					output.WriteByte(tabByte)
-
-					// This gives plenty precision; we are mostly interested in
-					// the first or maybe 2-3 significant digits
-					// https://play.golang.org/p/Ux-QmClaJG
-					// Also, gnomAD seems to use 6 bits of precision
-					// the bitSize == 64 allows us to round properly past 6 s.f
-					// Note: 'G' requires these numbers to be < 0 for proper precision
-					// (elase only 6 s.f total, rather than after decimal)
-					output.WriteString(strconv.FormatFloat(float64(len(hets))/effectiveSamples, 'G', precision, 64))
-				}
-
-				output.WriteByte(tabByte)
-
-				// Write missing samples
-				// homozygotes \t homozygosity
-				if len(homs) == 0 {
-					output.WriteString(emptyField)
-					output.WriteByte(tabByte)
-					output.WriteByte(zeroByte)
-				} else {
-					output.WriteString(strings.Join(homs, fieldDelim))
-					output.WriteByte(tabByte)
-					output.WriteString(strconv.FormatFloat(float64(len(homs))/effectiveSamples, 'G', precision, 64))
-				}
-
-				output.WriteByte(tabByte)
-
-				// Write missing samples
-				// missingGenos \t missingness
-				if len(missing) == 0 {
-					output.WriteString(emptyField)
-					output.WriteByte(tabByte)
-					output.WriteByte(zeroByte)
-				} else {
-					output.WriteString(strings.Join(missing, fieldDelim))
-					output.WriteByte(tabByte)
-					output.WriteString(strconv.FormatFloat(float64(len(missing))/numSamples, 'G', precision, 64))
-				}
-
-				// Write the sample minor allele frequency
-				output.WriteByte(tabByte)
-
-				output.WriteString(strconv.Itoa(ac))
-				output.WriteByte(tabByte)
-				output.WriteString(strconv.Itoa(an))
-				output.WriteByte(tabByte)
-
-				// TODO: can ac == 0 && (len(het) > 0 || len(hom) > 0) occur?
-				if ac == 0 {
-					output.WriteByte(zeroByte)
-				} else {
-					output.WriteString(strconv.FormatFloat(float64(ac)/float64(an), 'G', precision, 64))
-				}
-
-				/******************* Optional Fields ***********************/
-				if keepPos == true {
-					output.WriteByte(tabByte)
-					output.WriteString(record[posIdx])
-				}
-
-				if keepID == true {
-					output.WriteByte(tabByte)
-					output.WriteString(record[idIdx])
-				}
-
-				if keepInfo == true {
-					// Write the index of the allele, to allow users to segregate data in the INFO field
-					output.WriteByte(tabByte)
-					output.WriteString(strconv.Itoa(altIndices[i]))
-
-					// Write info for all indices
-					output.WriteByte(tabByte)
-					output.WriteString(record[infoIdx])
-				}
-
-				output.WriteByte(clByte)
 
 			}
 		}
@@ -657,7 +680,7 @@ func processLines(header []string, numChars int, config *Config, queue chan [][]
 		}
 	}
 
-	if output.Len() > 0 {
+	if !config.noOut && output.Len() > 0 {
 		fileMutex.Lock()
 
 		writer.Write(output.Bytes())

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -168,7 +169,9 @@ func TestHeader(t *testing.T) {
 }
 
 func TestWriteSampleListIfWanted(t *testing.T) {
-	config := Config{sampleListPath: "./test.sample_list"}
+	filePath := path.Join(t.TempDir(), "./test.sample_list")
+
+	config := Config{sampleListPath: filePath}
 
 	versionLine := "##fileformat=VCFv4.x"
 	header := strings.Join([]string{"#CHROM", "POS", "ID", "REF", "ALT", "QUAL",
@@ -188,7 +191,7 @@ func TestWriteSampleListIfWanted(t *testing.T) {
 
 	readVcf(&config, reader, w)
 
-	inFh, err := os.Open("./test.sample_list")
+	inFh, err := os.Open(filePath)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -225,7 +228,8 @@ func TestWriteSampleListIfWanted(t *testing.T) {
 }
 
 func TestWriteSampleListWhenNoSamples(t *testing.T) {
-	config := Config{sampleListPath: "./test.sample_list_2"}
+	filePath := path.Join(t.TempDir(), "./test.sample_list_2")
+	config := Config{sampleListPath: filePath}
 
 	versionLine := "##fileformat=VCFv4.x"
 	header := strings.Join([]string{"#CHROM", "POS", "ID", "REF", "ALT", "QUAL",
@@ -245,7 +249,7 @@ func TestWriteSampleListWhenNoSamples(t *testing.T) {
 
 	readVcf(&config, reader, w)
 
-	inFh, err := os.Open("./test.sample_list_2")
+	inFh, err := os.Open(filePath)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -2905,7 +2909,7 @@ func TestManyAlleles(t *testing.T) {
 
 // test that we can write a genotype matrix
 func TestGenotypeMatrix(t *testing.T) {
-	filePath := filepath.Join(os.TempDir(), "./test_genotype_matrix.feather")
+	filePath := filepath.Join(t.TempDir(), "./test_genotype_matrix.feather")
 
 	versionLine := "##fileformat=VCFv4.x"
 	header := strings.Join([]string{"#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "S1", "S2", "S3"}, "\t")
@@ -2983,15 +2987,12 @@ func TestGenotypeMatrix(t *testing.T) {
 				t.Fatal("Unknown row")
 			}
 		}
-
-		//Clean up arrow file
-		os.Remove(filePath)
 	}
 }
 
 // test that we can write a genotype matrix
 func TestNoOut(t *testing.T) {
-	filePath := filepath.Join(os.TempDir(), "./test_genotype_matrix.feather")
+	filePath := filepath.Join(t.TempDir(), "./test_genotype_matrix.feather")
 
 	versionLine := "##fileformat=VCFv4.x"
 	header := strings.Join([]string{"#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "S1", "S2", "S3"}, "\t")
@@ -3039,6 +3040,4 @@ func TestNoOut(t *testing.T) {
 	if arrowReader.NumRecords() == 0 {
 		t.Error("NOT OK: Expected to write dosage matrix")
 	}
-
-	os.Remove(filePath)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
@@ -2904,6 +2905,8 @@ func TestManyAlleles(t *testing.T) {
 
 // test that we can write a genotype matrix
 func TestGenotypeMatrix(t *testing.T) {
+	filePath := filepath.Join(os.TempDir(), "./test_genotype_matrix.feather")
+
 	versionLine := "##fileformat=VCFv4.x"
 	header := strings.Join([]string{"#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "S1", "S2", "S3"}, "\t")
 	row1 := strings.Join([]string{"1", "1000", "rs1", "A", "T", ".", "PASS", "DP=100", "GT", "1|1", "0|1", "0|0"}, "\t")
@@ -2916,7 +2919,7 @@ func TestGenotypeMatrix(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader(lines))
 
 	config := Config{emptyField: "!", fieldDelimiter: ";", allowedFilters: allowedFilters,
-		dosageMatrixOutPath: "./test_genotype_matrix.feather"}
+		dosageMatrixOutPath: filePath}
 
 	byteBuf := new(bytes.Buffer)
 	w := bufio.NewWriter(byteBuf)
@@ -2924,7 +2927,7 @@ func TestGenotypeMatrix(t *testing.T) {
 	readVcf(&config, reader, w)
 
 	// Read dosage matrix
-	file, err := os.Open("./test_genotype_matrix.feather")
+	file, err := os.Open(filePath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2982,12 +2985,14 @@ func TestGenotypeMatrix(t *testing.T) {
 		}
 
 		//Clean up arrow file
-		os.Remove("./test_genotype_matrix.feather")
+		os.Remove(filePath)
 	}
 }
 
 // test that we can write a genotype matrix
 func TestNoOut(t *testing.T) {
+	filePath := filepath.Join(os.TempDir(), "./test_genotype_matrix.feather")
+
 	versionLine := "##fileformat=VCFv4.x"
 	header := strings.Join([]string{"#CHROM", "POS", "ID", "REF", "ALT", "QUAL", "FILTER", "INFO", "FORMAT", "S1", "S2", "S3"}, "\t")
 	row1 := strings.Join([]string{"1", "1000", "rs1", "A", "T", ".", "PASS", "DP=100", "GT", "1|1", "0|1", "0|0"}, "\t")
@@ -2998,7 +3003,7 @@ func TestNoOut(t *testing.T) {
 	reader := bufio.NewReader(strings.NewReader(lines))
 
 	config := Config{emptyField: "!", fieldDelimiter: ";", allowedFilters: allowedFilters,
-		dosageMatrixOutPath: "./test_genotype_matrix.feather", noOut: true}
+		dosageMatrixOutPath: filePath, noOut: true}
 
 	byteBuf := new(bytes.Buffer)
 	w := bufio.NewWriter(byteBuf)
@@ -3018,7 +3023,7 @@ func TestNoOut(t *testing.T) {
 	}
 
 	// Read dosage matrix
-	file, err := os.Open("./test_genotype_matrix.feather")
+	file, err := os.Open(filePath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3035,6 +3040,5 @@ func TestNoOut(t *testing.T) {
 		t.Error("NOT OK: Expected to write dosage matrix")
 	}
 
-	//Clean up arrow file
-	os.Remove("./test_genotype_matrix.feather")
+	os.Remove(filePath)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -655,7 +655,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields := append(sharedFieldsGT, "0|0", "0|0", "0|0", "0|0")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an := makeHetHomozygotes(fields, header, "1")
+	actualHoms, actualHets, missing, _, ac, an := makeHetHomozygotes(fields, header, "1", true, true)
 
 	sampleMaf := float64(ac) / float64(an)
 
@@ -674,7 +674,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "0|1", "0|1", "0|1", "0|1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1", true, true)
 
 	sampleMaf = float64(ac) / float64(an)
 
@@ -694,7 +694,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, ".|.", ".|.", ".|1", "1|.")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1", true, true)
 
 	sampleMaf = 0
 
@@ -713,7 +713,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, ".|1", "0|1", "0|1", "0|1", strconv.FormatFloat(sampleMaf, 'G', 3, 64))
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1", true, true)
 
 	sampleMaf = float64(ac) / float64(an)
 
@@ -734,7 +734,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "1|.", "0|1", "0|1", "0|1", strconv.FormatFloat(sampleMaf, 'G', 3, 64))
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1", true, true)
 
 	sampleMaf = float64(ac) / float64(an)
 
@@ -753,7 +753,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "1|1", "1|1", "0|1", "0|1", strconv.FormatFloat(sampleMaf, 'G', 3, 64))
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1", true, true)
 
 	sampleMaf = float64(ac) / float64(an)
 
@@ -772,7 +772,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "1|2", "1|1", "0|1", "0|1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1", true, true)
 
 	sampleMaf = float64(ac) / float64(an)
 
@@ -794,7 +794,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "1|2", "1|1", "0|1", "0|1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2", true, true)
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 0 && len(actualHets) == 1 {
@@ -812,7 +812,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGTcomplex, "1|2:-0.03,-1.12,-5.00", "1|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2", true, true)
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 0 && len(actualHets) == 1 {
@@ -830,7 +830,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGTcomplex, "1|2|1:-0.03,-1.12,-5.00", "1|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2", true, true)
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 0 && len(actualHets) == 1 {
@@ -848,7 +848,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "1|2|1", "1|1", "0|1", "0|1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2", true, true)
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 0 && len(actualHets) == 1 {
@@ -866,7 +866,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGTcomplex, "2|2|2:-0.03,-1.12,-5.00", "1|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00", "0|1:-0.03,-1.12,-5.00")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2", true, true)
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 1 && len(actualHets) == 0 {
@@ -884,7 +884,7 @@ func TestMakeHetHomozygotes(t *testing.T) {
 	fields = append(sharedFieldsGT, "2|2|2", "1|1", "0|1", "0|1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "2", true, true)
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 1 && len(actualHets) == 0 {
@@ -911,7 +911,7 @@ func TestMakeHetHomozygotesHaploid(t *testing.T) {
 	fields := append(sharedFieldsGT, "0", ".", "1", "0")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an := makeHetHomozygotes(fields, header, "1")
+	actualHoms, actualHets, missing, _, ac, an := makeHetHomozygotes(fields, header, "1", true, true)
 	sampleMaf := float64(ac) / float64(an)
 
 	if len(actualHoms) == 1 && len(actualHets) == 0 && len(missing) == 1 {
@@ -929,7 +929,7 @@ func TestMakeHetHomozygotesHaploid(t *testing.T) {
 	fields = append(sharedFieldsGTcomplex, "0:1", ".:1", "1:1", "0:1")
 
 	// The allele index we want to test is always 1...unless it's a multiallelic site
-	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1")
+	actualHoms, actualHets, missing, _, ac, an = makeHetHomozygotes(fields, header, "1", true, true)
 	sampleMaf = float64(ac) / float64(an)
 
 	if len(actualHoms) == 1 && len(actualHets) == 0 && len(missing) == 1 {

--- a/main_test.go
+++ b/main_test.go
@@ -2950,17 +2950,17 @@ func TestGenotypeMatrix(t *testing.T) {
 		for rowIdx := 0; rowIdx < int(record.NumRows()); rowIdx++ {
 			switch record.Column(0).(*array.String).Value(rowIdx) {
 			case "chr1:1000:A:T":
-				genotypeS1 := record.Column(1).(*array.Int16).Value(rowIdx)
-				genotypeS2 := record.Column(2).(*array.Int16).Value(rowIdx)
-				genotypeS3 := record.Column(3).(*array.Int16).Value(rowIdx)
+				genotypeS1 := record.Column(1).(*array.Uint16).Value(rowIdx)
+				genotypeS2 := record.Column(2).(*array.Uint16).Value(rowIdx)
+				genotypeS3 := record.Column(3).(*array.Uint16).Value(rowIdx)
 
 				if genotypeS1 != 2 || genotypeS2 != 1 || genotypeS3 != 0 {
 					t.Error("NOT OK: Expected 2,1,0, got", genotypeS1, genotypeS2, genotypeS3)
 				}
 			case "chr2:200:C:G":
-				genotypeS1 := record.Column(1).(*array.Int16).Value(rowIdx)
-				genotypeS2 := record.Column(2).(*array.Int16).Value(rowIdx)
-				genotypeS3 := record.Column(3).(*array.Int16).Value(rowIdx)
+				genotypeS1 := record.Column(1).(*array.Uint16).Value(rowIdx)
+				genotypeS2 := record.Column(2).(*array.Uint16).Value(rowIdx)
+				genotypeS3 := record.Column(3).(*array.Uint16).Value(rowIdx)
 
 				if genotypeS1 != 1 || genotypeS2 != 0 || genotypeS3 != 2 {
 					t.Error("NOT OK: Expected 1,0,2, got", genotypeS1, genotypeS2, genotypeS3)
@@ -2974,7 +2974,7 @@ func TestGenotypeMatrix(t *testing.T) {
 					t.Error("NOT OK: Expected null value for S2")
 				}
 
-				genotypeS3 := record.Column(3).(*array.Int16).Value(rowIdx)
+				genotypeS3 := record.Column(3).(*array.Uint16).Value(rowIdx)
 
 				if genotypeS3 != 2 {
 					t.Error("NOT OK: Expected dosage of 2 for S3 got ", genotypeS3)


### PR DESCRIPTION
* Add noOut option which prevents writing the annotation to stdout/file. If dosageOut is not provided (no dosage requested), noOut can't be used 
* Fixes storing nil dosage for missing genotype in multi allelic case
* Pass arrow ipc.Option more idiomatically
* Rename NewArrowWriter to NewArrowIPCFileWriter for clarity 