### PR TITLE
[dosage] Switch to uint8 for dosages

### DIFF
--- a/main.go
+++ b/main.go
@@ -324,7 +324,7 @@ func readVcf(config *Config, reader *bufio.Reader, writer *bufio.Writer) {
 			fieldTypes := make([]arrow.DataType, len(fieldNames))
 			fieldTypes[0] = arrow.BinaryTypes.String
 			for i := 1; i < len(fieldNames); i++ {
-				fieldTypes[i] = arrow.PrimitiveTypes.Uint16
+				fieldTypes[i] = arrow.PrimitiveTypes.Uint8
 			}
 
 			file, err := os.Create(config.dosageMatrixOutPath)
@@ -1067,7 +1067,7 @@ SAMPLES:
 				totalGtCount += 2
 
 				if needsDosages {
-					dosages = append(dosages, uint16(0))
+					dosages = append(dosages, uint8(0))
 				}
 
 				continue SAMPLES
@@ -1086,7 +1086,7 @@ SAMPLES:
 					}
 
 					if needsDosages {
-						dosages = append(dosages, uint16(1))
+						dosages = append(dosages, uint8(1))
 					}
 
 					continue SAMPLES
@@ -1102,7 +1102,7 @@ SAMPLES:
 					}
 
 					if needsDosages {
-						dosages = append(dosages, uint16(2))
+						dosages = append(dosages, uint8(2))
 					}
 
 					continue SAMPLES
@@ -1170,7 +1170,11 @@ SAMPLES:
 		totalAltCount += altCount
 
 		if needsDosages {
-			dosages = append(dosages, uint16(altCount))
+			if altCount <= 255 {
+				dosages = append(dosages, uint8(altCount))
+			} else {
+				dosages = append(dosages, uint8(255))
+			}
 		}
 
 		if altCount == 0 {

--- a/main_test.go
+++ b/main_test.go
@@ -2954,17 +2954,17 @@ func TestGenotypeMatrix(t *testing.T) {
 		for rowIdx := 0; rowIdx < int(record.NumRows()); rowIdx++ {
 			switch record.Column(0).(*array.String).Value(rowIdx) {
 			case "chr1:1000:A:T":
-				genotypeS1 := record.Column(1).(*array.Uint16).Value(rowIdx)
-				genotypeS2 := record.Column(2).(*array.Uint16).Value(rowIdx)
-				genotypeS3 := record.Column(3).(*array.Uint16).Value(rowIdx)
+				genotypeS1 := record.Column(1).(*array.Uint8).Value(rowIdx)
+				genotypeS2 := record.Column(2).(*array.Uint8).Value(rowIdx)
+				genotypeS3 := record.Column(3).(*array.Uint8).Value(rowIdx)
 
 				if genotypeS1 != 2 || genotypeS2 != 1 || genotypeS3 != 0 {
 					t.Error("NOT OK: Expected 2,1,0, got", genotypeS1, genotypeS2, genotypeS3)
 				}
 			case "chr2:200:C:G":
-				genotypeS1 := record.Column(1).(*array.Uint16).Value(rowIdx)
-				genotypeS2 := record.Column(2).(*array.Uint16).Value(rowIdx)
-				genotypeS3 := record.Column(3).(*array.Uint16).Value(rowIdx)
+				genotypeS1 := record.Column(1).(*array.Uint8).Value(rowIdx)
+				genotypeS2 := record.Column(2).(*array.Uint8).Value(rowIdx)
+				genotypeS3 := record.Column(3).(*array.Uint8).Value(rowIdx)
 
 				if genotypeS1 != 1 || genotypeS2 != 0 || genotypeS3 != 2 {
 					t.Error("NOT OK: Expected 1,0,2, got", genotypeS1, genotypeS2, genotypeS3)
@@ -2978,7 +2978,7 @@ func TestGenotypeMatrix(t *testing.T) {
 					t.Error("NOT OK: Expected null value for S2")
 				}
 
-				genotypeS3 := record.Column(3).(*array.Uint16).Value(rowIdx)
+				genotypeS3 := record.Column(3).(*array.Uint8).Value(rowIdx)
 
 				if genotypeS3 != 2 {
 					t.Error("NOT OK: Expected dosage of 2 for S3 got ", genotypeS3)


### PR DESCRIPTION
* Halves the memory usage and disk space
* Properly handles overflow 