### PR TITLE
[WIP] use nils for reference genotypes

### DIFF
--- a/main.go
+++ b/main.go
@@ -1066,8 +1066,10 @@ SAMPLES:
 			if sampleGenotypeField[0] == '0' && sampleGenotypeField[2] == '0' {
 				totalGtCount += 2
 
+				// We encode reference dosages as nil, since they are the most common
+				// and Arrow only stores non-nil values (nils are held in a validity bitmask)
 				if needsDosages {
-					dosages = append(dosages, uint8(0))
+					dosages = append(dosages, nil)
 				}
 
 				continue SAMPLES
@@ -1115,8 +1117,9 @@ SAMPLES:
 					missing = append(missing, header[i])
 				}
 
+				// We encode missing dosages as 0, since nil is reserved for reference
 				if needsDosages {
-					dosages = append(dosages, nil)
+					dosages = append(dosages, uint8(0))
 				}
 
 				continue SAMPLES
@@ -1153,7 +1156,7 @@ SAMPLES:
 				}
 
 				if needsDosages {
-					dosages = append(dosages, nil)
+					dosages = append(dosages, uint8(0))
 				}
 
 				continue SAMPLES
@@ -1170,6 +1173,9 @@ SAMPLES:
 		totalAltCount += altCount
 
 		if needsDosages {
+			if altCount == 0 {
+				dosages = append(dosages, nil)
+			}
 			if altCount <= 255 {
 				dosages = append(dosages, uint8(altCount))
 			} else {

--- a/main_test.go
+++ b/main_test.go
@@ -2956,26 +2956,23 @@ func TestGenotypeMatrix(t *testing.T) {
 			case "chr1:1000:A:T":
 				genotypeS1 := record.Column(1).(*array.Uint8).Value(rowIdx)
 				genotypeS2 := record.Column(2).(*array.Uint8).Value(rowIdx)
-				genotypeS3 := record.Column(3).(*array.Uint8).Value(rowIdx)
 
-				if genotypeS1 != 2 || genotypeS2 != 1 || genotypeS3 != 0 {
-					t.Error("NOT OK: Expected 2,1,0, got", genotypeS1, genotypeS2, genotypeS3)
+				// 1|1 -> 2, 0|1 -> 1, 0|0 -> nil
+				if genotypeS1 != 2 || genotypeS2 != 1 || !record.Column(3).IsNull(rowIdx) {
+					t.Error("NOT OK: Expected 2,1,nil, got", genotypeS1, genotypeS2, record.Column(2).(*array.Uint8).Value(rowIdx))
 				}
 			case "chr2:200:C:G":
 				genotypeS1 := record.Column(1).(*array.Uint8).Value(rowIdx)
-				genotypeS2 := record.Column(2).(*array.Uint8).Value(rowIdx)
 				genotypeS3 := record.Column(3).(*array.Uint8).Value(rowIdx)
 
-				if genotypeS1 != 1 || genotypeS2 != 0 || genotypeS3 != 2 {
-					t.Error("NOT OK: Expected 1,0,2, got", genotypeS1, genotypeS2, genotypeS3)
+				if genotypeS1 != 1 || !record.Column(2).IsNull(rowIdx) || genotypeS3 != 2 {
+					t.Error("NOT OK: Expected 1,0,2, got", genotypeS1, record.Column(2).(*array.Uint8).Value(rowIdx), genotypeS3)
 				}
 			case "chr22:300:G:T":
-				if !record.Column(1).IsNull(rowIdx) {
-					t.Error("NOT OK: Expected null value for S1")
-				}
-
-				if !record.Column(2).IsNull(rowIdx) {
-					t.Error("NOT OK: Expected null value for S2")
+				genotypeS1 := record.Column(1).(*array.Uint8).Value(rowIdx)
+				genotypeS2 := record.Column(2).(*array.Uint8).Value(rowIdx)
+				if genotypeS1 != 0 || genotypeS2 != 0 {
+					t.Error("NOT OK: Expected missing genotypes to be represented as 0, got", genotypeS1, genotypeS2)
 				}
 
 				genotypeS3 := record.Column(3).(*array.Uint8).Value(rowIdx)


### PR DESCRIPTION
* Switches to nils for reference values, 0 for missing

This should result in large space savings, since most sites in the genome will be reference, and Arrow does not store nil values.

This is WIP until we put it behind an Extension Type so that users don't need to think about it, or we agree as a group that we're ok with users thinking about it and directly expose it (nils for reference sites). If we decide to directly expose it we'll need to document the choice, and thread it through ancestry, PRS.