### PR TITLE
switch to int8 dosages, with no null

### DIFF
--- a/arrow/arrow.go
+++ b/arrow/arrow.go
@@ -21,8 +21,8 @@ type ArrowWriter struct {
 // must match. The number of rows in each chunk is determined by chunkSize.
 // The ArrowWriter will write to filePath.
 // This writing operation is threadsafe.
-func NewArrowIPCFileWriter(f *os.File, fieldNames []string, fieldTypes []arrow.DataType, options ...ipc.Option) (*ArrowWriter, error) {
-	return NewArrowIPCFileWriterWithSchema(f, makeSchema(fieldNames, fieldTypes), options...)
+func NewArrowIPCFileWriter(f *os.File, fieldNames []string, fieldTypes []arrow.DataType, nullable bool, options ...ipc.Option) (*ArrowWriter, error) {
+	return NewArrowIPCFileWriterWithSchema(f, makeSchema(fieldNames, fieldTypes, nullable), options...)
 }
 
 func NewArrowIPCFileWriterWithSchema(f *os.File, schema *arrow.Schema, options ...ipc.Option) (*ArrowWriter, error) {
@@ -321,10 +321,10 @@ func appendBool(builder array.Builder, val any) error {
 	return fmt.Errorf("type mismatch, expected bool")
 }
 
-func makeSchema(fieldNames []string, fieldTypes []arrow.DataType) *arrow.Schema {
+func makeSchema(fieldNames []string, fieldTypes []arrow.DataType, nullable bool) *arrow.Schema {
 	fields := make([]arrow.Field, len(fieldTypes))
 	for i, dataType := range fieldTypes {
-		fields[i] = arrow.Field{Name: fieldNames[i], Type: dataType, Nullable: true}
+		fields[i] = arrow.Field{Name: fieldNames[i], Type: dataType, Nullable: nullable}
 	}
 
 	schema := arrow.NewSchema(fields, nil)

--- a/main.go
+++ b/main.go
@@ -324,7 +324,7 @@ func readVcf(config *Config, reader *bufio.Reader, writer *bufio.Writer) {
 			fieldTypes := make([]arrow.DataType, len(fieldNames))
 			fieldTypes[0] = arrow.BinaryTypes.String
 			for i := 1; i < len(fieldNames); i++ {
-				fieldTypes[i] = arrow.PrimitiveTypes.Uint8
+				fieldTypes[i] = arrow.PrimitiveTypes.Int8
 			}
 
 			file, err := os.Create(config.dosageMatrixOutPath)
@@ -1067,7 +1067,7 @@ SAMPLES:
 				totalGtCount += 2
 
 				if needsDosages {
-					dosages = append(dosages, uint8(0))
+					dosages = append(dosages, int8(0))
 				}
 
 				continue SAMPLES
@@ -1086,7 +1086,7 @@ SAMPLES:
 					}
 
 					if needsDosages {
-						dosages = append(dosages, uint8(1))
+						dosages = append(dosages, int8(1))
 					}
 
 					continue SAMPLES
@@ -1102,7 +1102,7 @@ SAMPLES:
 					}
 
 					if needsDosages {
-						dosages = append(dosages, uint8(2))
+						dosages = append(dosages, int8(2))
 					}
 
 					continue SAMPLES
@@ -1116,7 +1116,7 @@ SAMPLES:
 				}
 
 				if needsDosages {
-					dosages = append(dosages, nil)
+					dosages = append(dosages, -1)
 				}
 
 				continue SAMPLES
@@ -1153,7 +1153,7 @@ SAMPLES:
 				}
 
 				if needsDosages {
-					dosages = append(dosages, nil)
+					dosages = append(dosages, -1)
 				}
 
 				continue SAMPLES
@@ -1170,10 +1170,10 @@ SAMPLES:
 		totalAltCount += altCount
 
 		if needsDosages {
-			if altCount <= 255 {
-				dosages = append(dosages, uint8(altCount))
+			if altCount <= 127 {
+				dosages = append(dosages, int8(altCount))
 			} else {
-				dosages = append(dosages, uint8(255))
+				dosages = append(dosages, int8(127))
 			}
 		}
 

--- a/main.go
+++ b/main.go
@@ -333,7 +333,7 @@ func readVcf(config *Config, reader *bufio.Reader, writer *bufio.Writer) {
 			}
 			defer file.Close()
 
-			arrowWriter, err = bystroArrow.NewArrowIPCFileWriter(file, fieldNames, fieldTypes, ipc.WithZstd())
+			arrowWriter, err = bystroArrow.NewArrowIPCFileWriter(file, fieldNames, fieldTypes, false, ipc.WithZstd())
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/main.go
+++ b/main.go
@@ -1116,7 +1116,7 @@ SAMPLES:
 				}
 
 				if needsDosages {
-					dosages = append(dosages, -1)
+					dosages = append(dosages, int8(-1))
 				}
 
 				continue SAMPLES
@@ -1153,7 +1153,7 @@ SAMPLES:
 				}
 
 				if needsDosages {
-					dosages = append(dosages, -1)
+					dosages = append(dosages, int8(-1))
 				}
 
 				continue SAMPLES

--- a/main_test.go
+++ b/main_test.go
@@ -2952,35 +2952,21 @@ func TestGenotypeMatrix(t *testing.T) {
 		}
 
 		for rowIdx := 0; rowIdx < int(record.NumRows()); rowIdx++ {
+			genotypeS1 := record.Column(1).(*array.Int8).Value(rowIdx)
+			genotypeS2 := record.Column(2).(*array.Int8).Value(rowIdx)
+			genotypeS3 := record.Column(3).(*array.Int8).Value(rowIdx)
+
 			switch record.Column(0).(*array.String).Value(rowIdx) {
 			case "chr1:1000:A:T":
-				genotypeS1 := record.Column(1).(*array.Uint8).Value(rowIdx)
-				genotypeS2 := record.Column(2).(*array.Uint8).Value(rowIdx)
-				genotypeS3 := record.Column(3).(*array.Uint8).Value(rowIdx)
-
 				if genotypeS1 != 2 || genotypeS2 != 1 || genotypeS3 != 0 {
 					t.Error("NOT OK: Expected 2,1,0, got", genotypeS1, genotypeS2, genotypeS3)
 				}
 			case "chr2:200:C:G":
-				genotypeS1 := record.Column(1).(*array.Uint8).Value(rowIdx)
-				genotypeS2 := record.Column(2).(*array.Uint8).Value(rowIdx)
-				genotypeS3 := record.Column(3).(*array.Uint8).Value(rowIdx)
-
 				if genotypeS1 != 1 || genotypeS2 != 0 || genotypeS3 != 2 {
 					t.Error("NOT OK: Expected 1,0,2, got", genotypeS1, genotypeS2, genotypeS3)
 				}
 			case "chr22:300:G:T":
-				if !record.Column(1).IsNull(rowIdx) {
-					t.Error("NOT OK: Expected null value for S1")
-				}
-
-				if !record.Column(2).IsNull(rowIdx) {
-					t.Error("NOT OK: Expected null value for S2")
-				}
-
-				genotypeS3 := record.Column(3).(*array.Uint8).Value(rowIdx)
-
-				if genotypeS3 != 2 {
+				if genotypeS1 != -1 && genotypeS2 != -1 && genotypeS3 != 2 {
 					t.Error("NOT OK: Expected dosage of 2 for S3 got ", genotypeS3)
 				}
 			default:


### PR DESCRIPTION
* Improves performance, decreases memory usage in pandas dramatically (float64->int8, since pandas treats NaN as float64, requiring all values to be cast to float64 as the most conservative type)